### PR TITLE
Fix / update post comments

### DIFF
--- a/app/controllers/posts/comments_controller.rb
+++ b/app/controllers/posts/comments_controller.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class Posts::CommentsController < Posts::ApplicationController
-  before_action :set_post, only: %i[respond create edit update destroy]
-
   def respond
     @comment = PostComment.new
     authorize @comment
 
+    @post = resource_post
     @parent_comment = PostComment.find(params[:comment_id])
   end
 
@@ -14,6 +13,7 @@ class Posts::CommentsController < Posts::ApplicationController
     @comment = PostComment.find(params[:id])
     authorize @comment
 
+    @post = resource_post
     @parent_comment = @comment.parent
   end
 
@@ -21,6 +21,7 @@ class Posts::CommentsController < Posts::ApplicationController
     @comment = PostComment.new(comment_params.merge(post_id: params[:post_id], user_id: current_user.id))
     authorize @comment
 
+    @post = resource_post
     if @comment.save
       flash[:success] = I18n.t(".flash.success.#{controller_name}.#{params[:action]}")
       render turbo_stream: [
@@ -49,6 +50,7 @@ class Posts::CommentsController < Posts::ApplicationController
     comment = PostComment.find(params[:id])
     authorize comment
 
+    @post = resource_post
     if comment.update(comment_params)
       flash[:success] = I18n.t(".flash.success.#{controller_name}.#{params[:action]}")
       render turbo_stream: [
@@ -76,6 +78,7 @@ class Posts::CommentsController < Posts::ApplicationController
     comment = PostComment.find(params[:id])
     authorize comment
 
+    @post = resource_post
     comment.destroy
 
     flash[:success] = I18n.t(".flash.success.#{controller_name}.#{params[:action]}")
@@ -98,10 +101,6 @@ class Posts::CommentsController < Posts::ApplicationController
   end
 
   private
-
-  def set_post
-    @post = Post.find(params[:post_id])
-  end
 
   def comment_params
     params.require(:post_comment).permit(:content, :parent_id)

--- a/app/controllers/posts/comments_controller.rb
+++ b/app/controllers/posts/comments_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Posts::CommentsController < Posts::ApplicationController
-  before_action :set_post, only: %i[respond create update destroy]
+  before_action :set_post, only: %i[respond create edit update destroy]
 
   def respond
     @comment = PostComment.new
@@ -13,6 +13,8 @@ class Posts::CommentsController < Posts::ApplicationController
   def edit
     @comment = PostComment.find(params[:id])
     authorize @comment
+
+    @parent_comment = @comment.parent
   end
 
   def create

--- a/app/javascript/controllers/scroll_to_parent_controller.js
+++ b/app/javascript/controllers/scroll_to_parent_controller.js
@@ -6,7 +6,6 @@ export default class extends Controller {
   static targets = [
     'comment',
     'form',
-    'textarea',
   ];
 
   scroll(e) {

--- a/app/models/post_comment.rb
+++ b/app/models/post_comment.rb
@@ -18,7 +18,7 @@ class PostComment < ApplicationRecord
   belongs_to :post
   belongs_to :user, optional: true
 
-  has_ancestry
+  has_ancestry orphan_strategy: :destroy
 
   include PostCommentRepository
 end

--- a/app/repositories/post_like_repository.rb
+++ b/app/repositories/post_like_repository.rb
@@ -4,7 +4,6 @@ module PostLikeRepository
   extend ActiveSupport::Concern
 
   included do
-    scope :likes_from, ->(user) { joins(:user).where(user: { id: user.id }) }
     scope :likes_for, ->(post) { joins(:post).where(post: { id: post.id }) }
   end
 end

--- a/app/views/posts/comments/edit.html.slim
+++ b/app/views/posts/comments/edit.html.slim
@@ -6,6 +6,7 @@
       = render partial: 'posts/comments/shared/form',
                locals: { \
                  comment: @comment, \
-                 url: post_comment_path(@comment.post), \
-                 turbo_method: :patch \
+                 url: post_comment_path(@post), \
+                 turbo_method: :patch, \
+                 parent_comment: @parent_comment \
                }

--- a/app/views/posts/comments/respond.html.slim
+++ b/app/views/posts/comments/respond.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag dom_id(@parent_comment, :respond) do
-  .card.my-3
+  .card.mt-2.mb-3
     .card-header *{ class: %w[d-flex justify-content-between \
       align-items-center bg-secondary-subtle] }
       .ms-2
@@ -14,7 +14,7 @@
                   data: { \
                     turbo_frame: '_top' \
                   }, \
-                  class: 'fs-5 link- secondary' do
+                  class: 'fs-5 link-secondary' do
           i.bi.bi-x
     .px-3.pt-3.pb-2
       = render partial: 'posts/comments/shared/form', \

--- a/app/views/posts/comments/respond.html.slim
+++ b/app/views/posts/comments/respond.html.slim
@@ -1,4 +1,4 @@
-= turbo_frame_tag 'respond' do
+= turbo_frame_tag dom_id(@parent_comment, :respond) do
   .card.my-3
     .card-header *{ class: %w[d-flex justify-content-between \
       align-items-center bg-secondary-subtle] }

--- a/app/views/posts/comments/shared/_comment.html.slim
+++ b/app/views/posts/comments/shared/_comment.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag dom_id(comment) do
-  .card.my-3 data-scroll-to-parent-target='comment'
+  .card.mt-3.mb-2 data-scroll-to-parent-target='comment'
     .card-header.d-flex.justify-content-between.bg-secondary-subtle
       .d-flex.gap-3.justify-content-start.align-items-center
         div
@@ -12,7 +12,7 @@
           = link_to edit_post_comment_path(comment.post, comment), \
                     class: 'fs-6' do
             i.bi.bi-pencil-square
-        - if policy(comment).destroy? && !comment.has_children?
+        - if policy(comment).destroy?
           = link_to post_comment_path(comment.post, comment), \
                     data: { \
                       turbo_method: :delete, \
@@ -23,7 +23,7 @@
             i.bi.bi-trash
     .ps-3.pt-3.pb-2
       = comment.content
-      - if user_signed_in? && !comment.has_children?
+      - if user_signed_in?
         .d-block.mt-2
           = link_to t('.respond'), \
                     post_comment_respond_path(comment.post, comment), \

--- a/app/views/posts/comments/shared/_comment.html.slim
+++ b/app/views/posts/comments/shared/_comment.html.slim
@@ -28,10 +28,11 @@
           = link_to t('.respond'), \
                     post_comment_respond_path(comment.post, comment), \
                     data: { \
-                      turbo_frame: 'respond', \
+                      turbo_frame: dom_id(comment, :respond), \
                       action: 'click->scroll-to-parent#respond' \
                     }, \
                     class: 'btn btn-sm btn-outline-primary'
     .ps-3.pb-2
       = render partial: 'posts/comments/shared/comment', \
                collection: comment.children
+  = turbo_frame_tag dom_id(comment, :respond)


### PR DESCRIPTION
# Changes
closes #10 
- [x] Updates respond a comment feature - now appears under the comment which is to be responded to.
- [x] Adds ability to respond any comment (not only the top one)
- [x] Adds ability to remove a comment (this action removes all the descendant comments)
- [x] Fixes comment editing
- [x] Fixed close response button

# Demo
## Respond in place
![image](https://github.com/johanla0/rails-project-64/assets/59951682/4ba9d1d0-a608-4c8c-aa68-bfc858daa2e7)
## Respond to any comment
![image](https://github.com/johanla0/rails-project-64/assets/59951682/659079f1-502a-4d4e-a067-1b5453e61f48)
## Remove any comment
Just removed the comment with content "1"
![image](https://github.com/johanla0/rails-project-64/assets/59951682/8d81de7e-48a6-4982-9e90-7db27a6d33c4)
## Fixed edit
Previously we have not considered parent comment
![image](https://github.com/johanla0/rails-project-64/assets/59951682/ba478063-87c9-4358-a0fa-84cc103d773d)
